### PR TITLE
mkdir - ignore if exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,19 @@
-
 version: 2.1
 workflows:
   build-deploy:
     jobs:
-      #- test-locally
+      - test
       - publish:
-          #requires:
-          #  - test-locally
+          requires:
+            - test
           filters:
             branches:
               only: master
 
 jobs:
-  test-locally:
+  test:
     docker:
-      - image: circleci/node:10
+      - image: cimg/base:latest
     working_directory: ~/repo
     steps:
       - checkout
@@ -33,7 +32,7 @@ jobs:
             bats test
   publish:
     docker:
-      - image: circleci/node:10
+      - image: cimg/base:latest
     working_directory: ~/repo
     steps:
       - checkout
@@ -42,9 +41,6 @@ jobs:
           name: Promote to prod
           command: |
             circleci orb publish promote eddiewebb/common_tasks@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} patch --token ${CIRCLECI_API_KEY}
-  
-
-
 
 commands:
   install-bats:
@@ -54,20 +50,20 @@ commands:
           name: Install BATS (bash testing)
           command: |
             cd /tmp && git clone https://github.com/bats-core/bats-core.git && cd bats-core
-            sudo ./install.sh /usr/local
+            ./install.sh /usr/local
       - run:
           name: Install YQ
           command: |
             curl -L https://github.com/mikefarah/yq/releases/download/2.1.1/yq_linux_amd64 -o yq
             chmod a+x yq
-            sudo mv yq /usr/local/bin/
+            mv yq /usr/local/bin/
   install-circleci:
     description: installs the new CIrcleCI CLI with orb support
     steps:
       - run: 
           name: Install CircleCI CLI (the new one)
           command: |
-            curl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh --fail --show-error | sudo bash
+            curl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh --fail --show-error | bash
             circleci version
             echo "Run circleci help"              
             circleci help

--- a/orb/run.yml
+++ b/orb/run.yml
@@ -125,7 +125,7 @@ commands:
 
             echo "Attempting to pull common task from: $TASK_REPO_URL"
 
-            mkdir /tmp/<<parameters.repo-name>>
+            mkdir -p /tmp/<<parameters.repo-name>>
             cd /tmp/<<parameters.repo-name>>
             git init -q > /dev/null
             git remote add origin ${TASK_REPO_URL} > /dev/null

--- a/orb/run.yml
+++ b/orb/run.yml
@@ -124,14 +124,17 @@ commands:
             TASK_REPO_URL=${TASK_REPO_URL/$CIRCLE_PROJECT_USERNAME/<<parameters.org-name>>}
 
             echo "Attempting to pull common task from: $TASK_REPO_URL"
+            if [ -d "/tmp/<<parameters.repo-name>>" ];then
+              echo "Task directory exists, skipping to pulling task"              
+              cd /tmp/<<parameters.repo-name>>
+            else
+              mkdir -p /tmp/<<parameters.repo-name>>
+              cd /tmp/<<parameters.repo-name>>
+              git init -q > /dev/null
+              git remote add origin ${TASK_REPO_URL} > /dev/null
+              git fetch -q origin > /dev/null
+            fi
 
-            mkdir -p /tmp/<<parameters.repo-name>>
-            cd /tmp/<<parameters.repo-name>>
-            git init -q > /dev/null
-            git remote add origin ${TASK_REPO_URL} > /dev/null
-            git fetch -q origin > /dev/null
             git checkout -q origin/master -- tasks/<<parameters.task-name>> > /dev/null
-            
-
             cd - > /dev/null
             bash /tmp/<<parameters.repo-name>>/tasks/<<parameters.task-name>>/<<parameters.run-name>>


### PR DESCRIPTION
I ran into an issue where if I used two of these steps on a single executor instance, the 2nd task would fail to run because mkdir would throw an exception if this directory already existed. 