### PR TITLE
Allow passing script parameters to the task

### DIFF
--- a/orb/commands/run_shared_task.yml
+++ b/orb/commands/run_shared_task.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     default: "run.bash"
     description: "(Advanced) Override entrypoint script"
+  run-params:
+    type: string
+    default: ""
+    description: "Parameters passed to the script"    
 
 
 steps:
@@ -49,4 +53,4 @@ steps:
 
         git checkout -q origin/master -- tasks/<<parameters.task-name>> > /dev/null
         cd - > /dev/null
-        bash /tmp/<<parameters.repo-name>>/tasks/<<parameters.task-name>>/<<parameters.run-name>>
+        bash /tmp/<<parameters.repo-name>>/tasks/<<parameters.task-name>>/<<parameters.run-name>> <<parameters.run-params>>

--- a/orb/examples/with_variables.yml
+++ b/orb/examples/with_variables.yml
@@ -11,3 +11,8 @@ usage:
         - common/common_task:
             task-name: demo-task
             run-params: value
+        - common/common_task:
+            task-name: demo-task
+            pre-steps:		             
+               - run: echo \"export SOME_VAR=value\" >> $BASH_ENV
+        

--- a/orb/examples/with_variables.yml
+++ b/orb/examples/with_variables.yml
@@ -10,5 +10,4 @@ usage:
       jobs:
         - common/common_task:
             task-name: demo-task
-            pre-steps:
-              - run: echo \"export SOME_VAR=value\" >> $BASH_ENV
+            run-params: value

--- a/orb/jobs/common_task.yml
+++ b/orb/jobs/common_task.yml
@@ -23,6 +23,10 @@ parameters:
     type: string
     default: "run.bash"
     description: "Override entrypoint script"
+  run-params:
+    type: string
+    default: ""
+    description: "Parameters passed to the script"
 
 executor: << parameters.executor >>
 steps:
@@ -32,3 +36,4 @@ steps:
       org-name: <<parameters.org-name>>
       repo-name: <<parameters.repo-name>>
       run-name: <<parameters.run-name>>
+      run-params: <<parameters.run-params>>

--- a/tasks/demo-task-with-parameters/run.bash
+++ b/tasks/demo-task-with-parameters/run.bash
@@ -2,4 +2,4 @@
 
 echo "Hello ${CIRCLE_USERNAME}"
 
-echo "and a parameter of: ${SOME_VAR}"
+echo "and a parameter of: ${1:-$SOME_VAR}"


### PR DESCRIPTION
This PR adds optional `run-params` parameter to job and command that allows to append any script parameters to the command instead of using environment variables for that. With that users can define their jobs with more fine grained parameters names and concatenate them into `run-params` as needed for each task.

```yml
jobs:
  my-params-job:
    parameters:
      param1:
        type: string
      param2:
        type: string
  steps:
    - common/run_shared_task:
        run-name: my-params-task
        run-params: << parameters.param1 >> << parameters.param2 >>
```